### PR TITLE
feat(workspace): added instructions for getting badges

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-name: pr
+name: CI
 on: pull_request
 jobs:
   test:

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -112,3 +112,14 @@ workflow
 
 - TODO: Prettier/ESLint
 - TODO: Add `no release` PR label to repo
+
+#### Badges:
+
+Add the following html Code to your readme, replacing the text where specified, to add fancy badges.
+
+```html
+<p align="center"> 
+  <img alt="CI" src="*full-link-to-repo*/actions/workflows/CI.yml/badge.svg" />
+  <img alt="license" src="https://img.shields.io/github/license/*github-username*/*name-of-repo*" />
+</p>
+```


### PR DESCRIPTION
included two badges: status of CI workflow and license. Also renamed `pr` workflow to `CI`